### PR TITLE
Add sentiment detection for negative tweets and respond with a random encouragement phrase

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -3,6 +3,7 @@
  */
 var twit = require('twit');
 var config = require('./config');
+var sentiment = require('./sentiment');
 
 var Twitter = new twit(config);
 
@@ -123,3 +124,37 @@ function ranDom(arr) {
   var index = Math.floor(Math.random()*arr.length);
   return arr[index];
 }
+
+
+// SENTIMENT DETECTION =================
+const hashtagStream = Twitter.stream('statuses/filter', {
+   track: '#100DaysOfCode'
+});
+
+hashtagStream.on('tweet', (tweet) => {
+
+  //  Setup the http call
+  var httpCall = sentiment.init()
+
+  // Don't do anything if it's the bot tweet
+  if (tweet.user.screen_name == '_100DaysOfCode') return;
+
+  httpCall.send("txt=" + tweet.text).end(function (result) {
+
+    var sentim = result.body.result.sentiment;
+    var confidence = parseFloat(result.body.result.confidence);
+
+    // if sentiment is Negative and the confidence is above 75%
+    if (sentim == 'Negative' && confidence >= 75) {
+
+      // get a random quote
+      var phrase = sentiment.randomQuote()
+      var screen_name = tweet.user.screen_name
+
+      // tweet a random encouragement phrase
+      tweetNow('@' + screen_name + ' ' + phrase)
+
+    }
+
+  });
+ })

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "twit": "^2.2.4"
+    "twit": "^2.2.4",
+    "unirest": "^0.5.1"
   },
   "repository": {
     "type": "git",

--- a/quotes.json
+++ b/quotes.json
@@ -20,6 +20,14 @@
         "Fall seven times, stand up eight.",
         "A problem is a chance for you to do your best.",
         "Problems are not stop signs, they are guidelines",
-        "Patience, persistence and perspiration make an unbeatable combination for success."
+        "Patience, persistence and perspiration make an unbeatable combination for success.",
+        "keep on keepin on!",
+        "Little by little, inch by inch, you've got this.",
+        "make yourself a cup of tea or coffee and go for a walk for a while.",
+        "i'm not giving up on you. Shake things up! Use that big brain of your to think your way out. Look for a new angle.",
+        "don't worry about a thing, cause every little thing's gonna be alright. - Bob Marley",
+        "it's a marathon, not a sprint.",
+        "When you are struggling...do not jump to any conclusions about your own capabilities.",
+        "<it always get darkest before dawn/> <when it gets dark, the stars come out/> <Rome wasn't built in a day/>"
     ]
 }

--- a/quotes.json
+++ b/quotes.json
@@ -1,0 +1,25 @@
+{
+    "quotes" : [
+        "With the new day comes new strength and new thoughts.",
+        "Always do your best. What you plant now, you will harvest later.",
+        "It always seems impossible until it's done.",
+        "Problems are not stop signs, they are guidelines.",
+        "The secret of getting ahead is getting started.",
+        "We should not give up and we should not allow the problem to defeat us.",
+        "Start where you are. Use what you have. Do what you can.",
+        "What you do today can improve all your tomorrows.",
+        "A creative man is motivated by the desire to achieve, not by the desire to beat others.",
+        "Accept the challenges so that you can feel the exhilaration of victory.",
+        "It does not matter how slowly you go as long as you do not stop.",
+        "Set your goals high, and don't stop till you get there.",
+        "Aim for the moon. If you miss, you may hit a star.",
+        "Ever tried. Ever failed. No matter. Try Again. Fail again. Fail better.",
+        "You can never quit. Winners never quit, and quitters never win.",
+        "Arriving at one goal is the starting point to another.",
+        "The forces of the Universe and I are with you. You’re awesome!",
+        "Fall seven times, stand up eight.",
+        "A problem is a chance for you to do your best.",
+        "Problems are not stop signs, they are guidelines",
+        "Patience, persistence and perspiration make an unbeatable combination for success."
+    ]
+}

--- a/sentiment.js
+++ b/sentiment.js
@@ -1,0 +1,35 @@
+const unirest = require('unirest');
+const fs = require("fs");
+
+/*
+  Get a new API key at https://market.mashape.com/vivekn/sentiment-3
+*/
+
+
+// Sentiment 3 Mashape API key
+var apiKey = "QqtO3XbGhFmshEmKBxy58FqKLvG3p1rx61ijsnaHTstuRd3jp0"
+
+var sentiment = {}
+
+sentiment.init = function () {
+  return unirest.post("https://community-sentiment.p.mashape.com/text/")
+  .header("X-Mashape-Key", apiKey)
+  .header("Content-Type", "application/x-www-form-urlencoded")
+  .header("Accept", "application/json")
+}
+
+
+sentiment.randomQuote = function () {
+  // Get content from file
+ var contents = fs.readFileSync("quotes.json");
+
+ // Define to JSON type
+ var jsonContent = JSON.parse(contents);
+
+ // Random number
+ var randomIndex = Math.floor(Math.random() * jsonContent.quotes.length)
+
+ return jsonContent.quotes[randomIndex]
+}
+
+module.exports = sentiment


### PR DESCRIPTION
I've added a sentiment detection feature for tweets that have Negative score using the [Sentiment 3](https://market.mashape.com/vivekn/sentiment-3). The Bot respond the tweet that is Negative and that has a confidence (accuracy) score more then 75%.

Here is an example of the output when starting the Bot
```shell
User: adrianlemess
Tweet: Day 6 and today I made some Read.Me from my old projects on github and then I still working on my AlertAware System #100DaysOfCode
{ result: { confidence: '94.0558', sentiment: 'Positive' } }

User: fullstackgeorge
Tweet: Need to start #100DaysOfCode
{ result: { confidence: '76.6938', sentiment: 'Negative' } }
@fullstackgeorge You can never quit. Winners never quit, and quitters never win.

Reply to follower. SUCCESS!
User: steph_chin
Tweet: Day 5: Using geolocation &amp; @OpenWeatherMap APIs in my weather app. Minimal fighting with my js code, stopping while I'm ahead #100daysofcode
{ result: { confidence: '51.4939', sentiment: 'Neutral' } }
```

In this case the Bot responded to the user with a random quote.
[Link to the tweet](https://twitter.com/_100DaysOfCode/status/817914076940668928)

