### PR TITLE
remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
     "npm",
     "retweet"
   ],
-  "engines": {
-    "node": "~6.1.0",
-    "npm": "~.3.8.6"
-  },
   "author": "aman mittal <@amanhimself>",
   "bugs": {
     "url": "https://github.com/amandeepmittal/100DaysOfCode/issues"


### PR DESCRIPTION
since node 8 is default on most PaaS.

Closes #89