### PR TITLE
fix:limit check on tweet characters

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -23,7 +23,7 @@ const retweet = () => {
     // when no errors
     if (!err) {
             const full_text_data = data.statuses[0].full_text ? data.statuses[0].full_text : undefined;
-            if ((data.statuses[0].full_text.length <140 ) && (data.statuses[0].full_text.split('#').length - 1 === 1) && (data.statuses[0].full_text.toLowerCase().includes("#100daysofcode"))){
+            if ((full_text_data <140 ) && (full_text_data.split('#').length - 1 === 1) && (full_text_data.toLowerCase().includes("#100daysofcode"))){
         // if there is only one hashtag get the tweet's ID
        
         let retweetID = data.statuses[0].id_str;

--- a/src/bot.js
+++ b/src/bot.js
@@ -16,14 +16,15 @@ const retweet = () => {
     q: config.query,
     result_type: config.result_type,
     lang: config.lang,
-    tweet_mode: "extended"
+    tweet_mode: 'extended'
   };
 
   TwitterBot.get('search/tweets', params, (err, data) => {
     // when no errors
     if (!err) {
-      if (data.statuses[0].full_text.split('#').length - 1 === 1) {
+            if ((data.statuses[0].full_text.length <140 ) && (data.statuses[0].full_text.split('#').length - 1 === 1) && (data.statuses[0].full_text.toLowerCase().includes("#100daysofcode"))){
         // if there is only one hashtag get the tweet's ID
+       
         let retweetID = data.statuses[0].id_str;
         console.log(data.statuses[0]);
         TwitterBot.post(

--- a/src/bot.js
+++ b/src/bot.js
@@ -22,8 +22,8 @@ const retweet = () => {
   TwitterBot.get('search/tweets', params, (err, data) => {
     // when no errors
     if (!err) {
-            const full_text_data = data.statuses[0].full_text ? data.statuses[0].full_text : undefined;
-            if ((full_text_data <140 ) && (full_text_data.split('#').length - 1 === 1) && (full_text_data.toLowerCase().includes("#100daysofcode"))){
+            const full_text_data = data.statuses?.[0]?.full_text;
+            if ((full_text_data <140 ) && (full_text_data?.split('#')?.length - 1 === 1) && (full_text_data?.toLowerCase()?.includes("#100daysofcode"))){
         // if there is only one hashtag get the tweet's ID
        
         let retweetID = data.statuses[0].id_str;

--- a/src/bot.js
+++ b/src/bot.js
@@ -22,6 +22,7 @@ const retweet = () => {
   TwitterBot.get('search/tweets', params, (err, data) => {
     // when no errors
     if (!err) {
+            const full_text_data = data.statuses[0].full_text ? data.statuses[0].full_text : undefined;
             if ((data.statuses[0].full_text.length <140 ) && (data.statuses[0].full_text.split('#').length - 1 === 1) && (data.statuses[0].full_text.toLowerCase().includes("#100daysofcode"))){
         // if there is only one hashtag get the tweet's ID
        


### PR DESCRIPTION
### Change proposed in this pull request:
Reduce spam retweets by modifying the bot logic as follows:

  - Apply a limit of 140 characters on the retrieved Tweets. This would only check the trimmed text in `full_text`.

  - The hashtag `#100DaysOfCode` must be present in the text. 
  
 ### Tests

#### Successful retweet according to the updated logic:
https://twitter.com/junaid046/status/1552798489809104897

#### Rejected Tweets:


- `full_text`: 
```
"RT @QuantScraper: keep on growing @CarolButWithAK ! let's support #WomenWhoCode #WomenInSTEM #WomenInTech 
#GirlsWhoCode #javascript #html #…",
```
- character count: 140

------

- `full_text`: 

```'Get 24hr assignment help in:\n' +
    'pay homework..\n' +
    'pay coursework\n' +
    'pay essay\n' +
    'pay write\n' +
    'pay biology\n' +
    'pay history\n' +
    'pay psychology\n' +
    'pay dissertation\n' +
    'pay research\n' +
    'pay paper due\n' +
    'pay math.\n' +
    'pay physics...\n' +
    'pay law.\n' +
    'pay statistics\n' +
    'pay lab report\n' +
    '#100DaysOfCode\n' +
    '#ElonMusk',
```

- character count: 250

------

- `full_text`: 

```
RT @Kasungwa_: The goal this Year is  to open our first physical campus in Kenya come October 2022 (@lux_academy and @DSEAfrica ) as �𝗨𝗫  𝗔𝗖…

```

- character count: 145




---
###### Thanks to [@miljan-fsd] from [parcel-react-app] for the template 👌

[@miljan-fsd]: https://github.com/miljan-fsd
[parcel-react-app]: https://github.com/miljan-fsd/parcel-react-app